### PR TITLE
Add initial implementation of webpack loader

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -1,0 +1,17 @@
+import 'babel-polyfill';
+
+import path from 'path';
+import introspectionQuery from './schema/introspectionQuery';
+import makeMinimalSchema from './schema/makeMinimalSchema';
+
+const graphql = require(path.join(process.cwd(), 'node_modules', 'graphql')).graphql;
+
+export default async function (source) {
+  const callback = this.async();
+  const schema = this.exec(source, this.resourcePath);
+  const initialResult = await graphql(schema, introspectionQuery);
+  const minimalSchema = makeMinimalSchema(initialResult.data.__schema);
+  const result = `module.exports = ${JSON.stringify(minimalSchema)};`;
+
+  callback(null, result)
+}

--- a/src/schema/makeMinimalSchema.js
+++ b/src/schema/makeMinimalSchema.js
@@ -1,0 +1,94 @@
+const isObject = val => val && typeof val === 'object';
+const removeNullsFromList = list => {
+  for (let item of list) {
+    removeNullsFromObject(item)
+  }
+};
+const removeNullsFromObject = obj => {
+  const itemKeys = Object.keys(obj);
+  for (let itemKey of itemKeys) {
+    const field = obj[itemKey];
+    if (Array.isArray(field)) {
+      removeNullsFromList(field);
+    } else if (isObject(field)) {
+      removeNullsFromObject(field)
+    } else if (field === null) {
+      delete obj[itemKey];
+    }
+  }
+};
+
+//TODO filter out interfaces
+export default function makeMinimalSchema(schema) {
+  removeNullsFromObject(schema);
+  const queryName = schema.queryType && schema.queryType.name;
+  const mutationName = schema.mutationType && schema.mutationType.name;
+  const subscriptionName = schema.subscriptionType && schema.subscriptionType.name;
+  const filteredTypes = schema.types.filter(type => !type.name.startsWith('__'));
+
+  for (let type of filteredTypes) {
+    if (type.fields) {
+      for (let field of type.fields) {
+        if (field.args) {
+          if (field.args.length) {
+            field.args = objArrayToHashMap(field.args);
+          } else {
+            delete field.args;
+          }
+        }
+      }
+      type.fields = objArrayToHashMap(type.fields);
+    }
+    if (type.enumValues) {
+      type.enumValues = objArrayToHashMap(type.enumValues);
+    }
+    if (type.inputFields) {
+      type.inputFields = objArrayToHashMap(type.inputFields)
+    }
+    if (type.possibleTypes) {
+      type.possibleTypes = objArrayToHashMap(type.possibleTypes);
+    }
+    if (type.interfaces) {
+      if (type.interfaces.length) {
+        type.interfaces = objArrayToHashMap(type.interfaces);
+      } else {
+        delete type.interfaces;
+      }
+    }
+  }
+  const filteredTypesMap = objArrayToHashMap(filteredTypes);
+  const filteredDirectives = schema.directives.filter(directive => {
+    return directive.name !== 'deprecated';
+  });
+  for (let directive of filteredDirectives) {
+    directive.args = objArrayToHashMap(directive.args);
+  }
+  const filteredDirectivesMap = objArrayToHashMap(filteredDirectives);
+  const querySchema = filteredTypesMap[queryName];
+  delete filteredTypesMap[queryName];
+  const mutationSchema = filteredTypesMap[mutationName];
+  delete filteredTypesMap[mutationName];
+  const subscriptionSchema = filteredTypesMap[subscriptionName];
+  delete filteredTypesMap[subscriptionName];
+
+  const finalResult = {
+    querySchema,
+    types: filteredTypesMap,
+    directives: filteredDirectivesMap
+  };
+  if (mutationSchema) {
+    finalResult.mutationSchema = mutationSchema;
+  }
+  if (subscriptionSchema) {
+    finalResult.subscriptionSchema = subscriptionSchema;
+  }
+  return finalResult;
+};
+
+const objArrayToHashMap = arr => {
+  const hashMap = {};
+  for (let field of arr) {
+    hashMap[field.name] = field;
+  }
+  return hashMap;
+};

--- a/src/schema/updateSchema.js
+++ b/src/schema/updateSchema.js
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import minimist from 'minimist';
 import introspectionQuery from './introspectionQuery';
+import makeMinimalSchema from './makeMinimalSchema';
 import fetch from 'isomorphic-fetch';
 
 // why instanceof is still a thing is beyond me...
@@ -32,101 +33,6 @@ export default async function updateSchema() {
     console.log(`Error writing schema to file: ${e}`)
   }
 }
-
-const isObject = val => val && typeof val === 'object';
-const removeNullsFromList = list => {
-  for (let item of list) {
-    removeNullsFromObject(item)
-  }
-};
-const removeNullsFromObject = obj => {
-  const itemKeys = Object.keys(obj);
-  for (let itemKey of itemKeys) {
-    const field = obj[itemKey];
-    if (Array.isArray(field)) {
-      removeNullsFromList(field);
-    } else if (isObject(field)) {
-      removeNullsFromObject(field)
-    } else if (field === null) {
-      delete obj[itemKey];
-    }
-  }
-};
-
-//TODO filter out interfaces
-const makeMinimalSchema = schema => {
-  removeNullsFromObject(schema);
-  const queryName = schema.queryType && schema.queryType.name;
-  const mutationName = schema.mutationType && schema.mutationType.name;
-  const subscriptionName = schema.subscriptionType && schema.subscriptionType.name;
-  const filteredTypes = schema.types.filter(type => !type.name.startsWith('__'));
-
-  for (let type of filteredTypes) {
-    if (type.fields) {
-      for (let field of type.fields) {
-        if (field.args) {
-          if (field.args.length) {
-            field.args = objArrayToHashMap(field.args);
-          } else {
-            delete field.args;
-          }
-        }
-      }
-      type.fields = objArrayToHashMap(type.fields);
-    }
-    if (type.enumValues) {
-      type.enumValues = objArrayToHashMap(type.enumValues);
-    }
-    if (type.inputFields) {
-      type.inputFields = objArrayToHashMap(type.inputFields)
-    }
-    if (type.possibleTypes) {
-      type.possibleTypes = objArrayToHashMap(type.possibleTypes);
-    }
-    if (type.interfaces) {
-      if (type.interfaces.length) {
-        type.interfaces = objArrayToHashMap(type.interfaces);
-      } else {
-        delete type.interfaces;
-      }
-    }
-  }
-  const filteredTypesMap = objArrayToHashMap(filteredTypes);
-  const filteredDirectives = schema.directives.filter(directive => {
-    return directive.name !== 'deprecated';
-  });
-  for (let directive of filteredDirectives) {
-    directive.args = objArrayToHashMap(directive.args);
-  }
-  const filteredDirectivesMap = objArrayToHashMap(filteredDirectives);
-  const querySchema = filteredTypesMap[queryName];
-  delete filteredTypesMap[queryName];
-  const mutationSchema = filteredTypesMap[mutationName];
-  delete filteredTypesMap[mutationName];
-  const subscriptionSchema = filteredTypesMap[subscriptionName];
-  delete filteredTypesMap[subscriptionName];
-
-  const finalResult = {
-    querySchema,
-    types: filteredTypesMap,
-    directives: filteredDirectivesMap
-  };
-  if (mutationSchema) {
-    finalResult.mutationSchema = mutationSchema;
-  }
-  if (subscriptionSchema) {
-    finalResult.subscriptionSchema = subscriptionSchema;
-  }
-  return finalResult;
-};
-
-const objArrayToHashMap = arr => {
-  const hashMap = {};
-  for (let field of arr) {
-    hashMap[field.name] = field;
-  }
-  return hashMap;
-};
 
 const getSchema = async inputArg => {
   if (urlRegex.test(inputArg)) {


### PR DESCRIPTION
This is a crude first attempt at a webpack loader that embeds the client schema instead of requiring a separate build step. Extracting this into `cashay-loader` (or even something more generic like `graphql-client-schema-loader`) is probably a good idea

**Usage:**

```javascript
import schema from 'cashay/lib/loader!./mySchema'
```
