### PR TITLE
Add transform-runtime to .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "stage-0"]
+  "presets": ["es2015", "stage-0"],
+  "plugins": ["transform-runtime"]
 }

--- a/package.json
+++ b/package.json
@@ -36,9 +36,11 @@
   "devDependencies": {
     "ava": "0.15.2",
     "babel-cli": "6.9.0",
+    "babel-plugin-transform-runtime": "^6.9.0",
     "babel-preset-es2015": "6.9.0",
     "babel-preset-stage-0": "6.5.0",
     "babel-register": "^6.9.0",
+    "babel-runtime": "^6.9.2",
     "coveralls": "^2.11.9",
     "nyc": "^6.4.4",
     "rimraf": "2.5.2",


### PR DESCRIPTION
By including the `transform-runtime` babel plugin, we make sure that the libary itself doesn't require any babel dependencies after it has been built as per the discussion in #50 