### PR TITLE
Use a true singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ const Authorization = `Bearer ${authToken}`;
 const transport = new HTTPTransport('/myEndpoint', {headers: {Authorization}});
 ```
 
-If you'd like to replace the global `cashay.transport`, you can call `cashay.setTransport(newTransport)`.
+If you'd like to replace the global `cashay.transport`, you can call just call `cashay.create({transport: newTransport})`.
 This is useful if you use custom `fetchOptions` that include an authorization token and you need to change it.
 
 ### Queries

--- a/README.md
+++ b/README.md
@@ -73,22 +73,25 @@ const store = createStore(rootReducer, {});
 
 Cashay is front-end agnostic, so instead of passing it through React context
 or making you replace `react-redux` with something non-vanilla,
-you can just export your singleton from where you created it.
+you can just import the singleton. This means it works well in SSR apps, too.
 ```js
+// in your client index.js
 const clientSchema = require('cashay!../server/utils/getCashaySchema.js');
-import {Cashay, HTTPTransport} from 'cashay';
-export const cashay = new Cashay(paramsObject);
+import {cashay, HTTPTransport} from 'cashay';
+cashay.create(paramsObject);
+
+// in a Component.js
+import {cashay} from 'cashay';
+cashay.query(...);
 ```
 
-The params that you can pass in are as follows (*required):
+The params that you can pass into the `create` method are as follows (*required):
 - *`store`: Your redux store
 - *`schema`: your client schema that cashay helped you make
 - *`transport`: An instance of `HTTPTransport` used to send off the query + variables to your GraphQL server.
 - `idFieldName`: Defaults to `id`, but you can call it whatever it is in your DB (eg Mongo uses `_id`)
 - `paginationWords`: The reserved words that you use for pagination. Defaults to an object with 4 properties: `first, last, after, before`. If, for example, your backend uses `count` instead of `first`, you'd send in `{first: 'count'}`.
 - `getToState`: A function to get to the cashay sub-state inside the redux state. Defaults to `store => store.getState().cashay`
-
-
 
 Now, whenever you need to query or mutate some data, just import your shiny new singleton!
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cashay",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "relay for the rest of us",
   "main": "lib/index.js",
   "bin": {

--- a/src/Cashay.js
+++ b/src/Cashay.js
@@ -26,26 +26,8 @@ const defaultPaginationWords = {
   last: 'last'
 };
 
-export default class Cashay {
-  constructor({store, transport, schema, getToState = defaultGetToState, paginationWords, idFieldName = 'id'}) {
-    // the redux store
-    this.store = store;
-
-    //the cashay state
-    this.getState = () => getToState(store);
-
-    // the reserved arguments for cusor-based pagination
-    this.paginationWords = Object.assign({}, defaultPaginationWords, paginationWords);
-
-    // the field that contains the UID
-    this.idFieldName = idFieldName;
-
-    // the default function to send the queryString to the server (usually HTTP or WS)
-    this.transport = transport;
-
-    // the client graphQL schema
-    this.schema = schema;
-
+class Cashay {
+  constructor() {
     // many mutations can share the same mutationName, making it hard to cache stuff without adding complexity
     // we can assume that a mutationName + the components it affects = a unique, reproduceable fullMutation
     // const example = {
@@ -118,6 +100,26 @@ export default class Cashay {
     this.normalizedDeps = {};
   }
 
+  create({store, transport, schema, getToState = defaultGetToState, paginationWords, idFieldName = 'id'}) {
+    // the redux store
+    this.store = store || this.store;
+
+    //the cashay state
+    this.getState = getToState ? () => getToState(store) : this.getState;
+
+    // the reserved arguments for cusor-based pagination
+    this.paginationWords = paginationWords ? Object.assign({}, defaultPaginationWords, paginationWords) : this.paginationWords;
+
+    // the field that contains the UID
+    this.idFieldName = idFieldName || this.idFieldName;
+
+    // the default function to send the queryString to the server (usually HTTP or WS)
+    this.transport = transport || this.transport;
+
+    // the client graphQL schema
+    this.schema = schema || this.schema;
+  }
+
   /**
    * a method given to a mutation callback that turns on a global.
    * if true, then we know to queue up a requery
@@ -133,6 +135,7 @@ export default class Cashay {
   setTransport(transport) {
     return this.transport = transport;
   }
+
   /**
    * A method that accepts a GraphQL query and returns a result using only local data.
    * If it cannot complete the request on local data alone, it also asks the server for the data that it does not have.
@@ -519,7 +522,7 @@ export default class Cashay {
       }
 
       const componentState = cashayDataState.variables[component];
-      // TODO using stateVars is wrong because vars could be static in the query, instead we need to check the schema + varDefs + vars 
+      // TODO using stateVars is wrong because vars could be static in the query, instead we need to check the schema + varDefs + vars
       const stateVars = key ? componentState[key] : componentState;
       if (!stateVars) {
         return rawState;
@@ -574,11 +577,11 @@ export default class Cashay {
   }
 
   subscriptionRemove(idToRemove) {
-    // 
+    //
   }
 
 }
-
+export default new Cashay();
 // const subscriber = (subscriptionString, handlers, variables) => {
 //   let baseChannel;
 //   for (let [key, value] of channelLookupMap.entries()) {
@@ -614,3 +617,4 @@ export default class Cashay {
 //       id,
 //     }
 //   }`]]);
+

--- a/src/Cashay.js
+++ b/src/Cashay.js
@@ -132,10 +132,6 @@ class Cashay {
     return this.transport;
   }
 
-  setTransport(transport) {
-    return this.transport = transport;
-  }
-
   /**
    * A method that accepts a GraphQL query and returns a result using only local data.
    * If it cannot complete the request on local data alone, it also asks the server for the data that it does not have.

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 export cashayReducer from './normalize/duck';
-export Cashay from './Cashay';
+export cashay from './Cashay';
 export HTTPTransport from './HTTPTransport';
 export transformSchema from './schema/transformSchema';

--- a/src/schema/cashay-loader.js
+++ b/src/schema/cashay-loader.js
@@ -3,7 +3,6 @@ module.exports = function(content) {
   this.cacheable && this.cacheable();
   const callback = this.async();
   // Execute the supplied javascript, receive promise:
-  
   const doc = this.exec(content, this.resource);
   doc.then(function (schema) {
     // Await the yield of a cashay schema:


### PR DESCRIPTION
Precursor to SSR #53
the package now exports a `cashay` singleton instead of a `Cashay` class that you have to turn into a singleton. This means no more dirty exporting from where you create it.

