### PR TITLE
added param to cashay-loader; changes api!

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,20 +31,22 @@ Cashay uses a client-safe portion of your GraphQL schema,
 similar to [GraphiQL](https://github.com/graphql/graphiql), but _way_ smaller.
 
 Since schemas change rapidly during development, Cashay includes a
-[Webpack](https://webpack.github.io/) loader to automatically refresh the schema on startup.
-You can include the schema on your client
+[Webpack](https://webpack.github.io/) loader to automatically refresh the schema
+on startup. You can include the schema on your client
 (likely near the instantiation of your [Cashay singleton](#creating-the-singleton))
 by using a `require()` statement:
 
 ```js
 const cashaySchema = require('cashay!../server/utils/getCashaySchema.js');
-///            cashay-loader ^^^     ^^^ module returning promise for a schema
+///            cashay-loader ^^^     ^^^ returns function for promise for schema
 ```
 
 **Note:** `cashay-loader` is automatically included with Cashay, just use it!
 
-All the loader needs is a module which exports a Promise for a schema that's
-been transformed by the Cashay's `transformSchema()` convenience function.
+All the loader needs is a module which exports a function that will return a
+Promise for a schema that's been transformed by the Cashay's
+`transformSchema()` convenience function.
+
 Ours looks like this:
 
 ```js
@@ -56,10 +58,16 @@ const {transformSchema} = require('cashay');
 const graphql = require('graphql').graphql;
 const rootSchema = require('../graphql/rootSchema');
 const r = require('../database/rethinkDriver');
-r.getPoolMaster().drain(); // optional pool draining if your schema starts a DB connection pool
-module.exports = transformSchema(rootSchema, graphql);
+module.exports = (params) => {
+  if (params === '?exitRethink') {
+    // optional pool draining if your schema starts a DB connection pool
+    r.getPoolMaster().drain();
+  }
+  return transformSchema(rootSchema, graphql);
+}
 ```
-If you cannot use webpack, see the [cashay-schema](./recipes/cashay-schema.md) recipe.
+If you cannot use webpack, see the [cashay-schema](./recipes/cashay-schema.md)
+recipe.
 
 ### Adding the reducer
 
@@ -90,7 +98,7 @@ cashay.query(...);
 The params that you can pass into the `create` method are as follows (*required):
 - *`store`: Your redux store
 - *`schema`: your client schema that cashay helped you make
-- *`transport`: An instance of `HTTPTransport` used to send off the query + variables to your GraphQL server. 
+- *`transport`: An instance of `HTTPTransport` used to send off the query + variables to your GraphQL server.
 - `idFieldName`: Defaults to `id`, but you can call it whatever it is in your DB (eg Mongo uses `_id`)
 - `paginationWords`: The reserved words that you use for pagination. Defaults to an object with 4 properties: `first, last, after, before`. If, for example, your backend uses `count` instead of `first`, you'd send in `{first: 'count'}`.
 - `getToState`: A function to get to the cashay sub-state inside the redux state. Defaults to `store => store.getState().cashay`

--- a/README.md
+++ b/README.md
@@ -31,22 +31,20 @@ Cashay uses a client-safe portion of your GraphQL schema,
 similar to [GraphiQL](https://github.com/graphql/graphiql), but _way_ smaller.
 
 Since schemas change rapidly during development, Cashay includes a
-[Webpack](https://webpack.github.io/) loader to automatically refresh the schema
-on startup. You can include the schema on your client
+[Webpack](https://webpack.github.io/) loader to automatically refresh the schema on startup.
+You can include the schema on your client
 (likely near the instantiation of your [Cashay singleton](#creating-the-singleton))
 by using a `require()` statement:
 
 ```js
 const cashaySchema = require('cashay!../server/utils/getCashaySchema.js');
-///            cashay-loader ^^^     ^^^ returns function for promise for schema
+///            cashay-loader ^^^     ^^^ module returning promise for a schema
 ```
 
 **Note:** `cashay-loader` is automatically included with Cashay, just use it!
 
-All the loader needs is a module which exports a function that will return a
-Promise for a schema that's been transformed by the Cashay's
-`transformSchema()` convenience function.
-
+All the loader needs is a module which exports a Promise for a schema that's
+been transformed by the Cashay's `transformSchema()` convenience function.
 Ours looks like this:
 
 ```js
@@ -58,16 +56,10 @@ const {transformSchema} = require('cashay');
 const graphql = require('graphql').graphql;
 const rootSchema = require('../graphql/rootSchema');
 const r = require('../database/rethinkDriver');
-module.exports = (params) => {
-  if (params === '?exitRethink') {
-    // optional pool draining if your schema starts a DB connection pool
-    r.getPoolMaster().drain();
-  }
-  return transformSchema(rootSchema, graphql);
-}
+r.getPoolMaster().drain(); // optional pool draining if your schema starts a DB connection pool
+module.exports = transformSchema(rootSchema, graphql);
 ```
-If you cannot use webpack, see the [cashay-schema](./recipes/cashay-schema.md)
-recipe.
+If you cannot use webpack, see the [cashay-schema](./recipes/cashay-schema.md) recipe.
 
 ### Adding the reducer
 
@@ -98,7 +90,7 @@ cashay.query(...);
 The params that you can pass into the `create` method are as follows (*required):
 - *`store`: Your redux store
 - *`schema`: your client schema that cashay helped you make
-- *`transport`: An instance of `HTTPTransport` used to send off the query + variables to your GraphQL server.
+- *`transport`: An instance of `HTTPTransport` used to send off the query + variables to your GraphQL server. 
 - `idFieldName`: Defaults to `id`, but you can call it whatever it is in your DB (eg Mongo uses `_id`)
 - `paginationWords`: The reserved words that you use for pagination. Defaults to an object with 4 properties: `first, last, after, before`. If, for example, your backend uses `count` instead of `first`, you'd send in `{first: 'count'}`.
 - `getToState`: A function to get to the cashay sub-state inside the redux state. Defaults to `store => store.getState().cashay`

--- a/src/schema/__tests__/cashay-loader-tests.js
+++ b/src/schema/__tests__/cashay-loader-tests.js
@@ -3,19 +3,7 @@ import test from 'ava';
 
 import cashayLoader from '../cashay-loader';
 
-class MockLoaderParent {
-  constructor(loader, testCallback) {
-    this.loader = loader;
-    this.callback = testCallback;
-  }
-  async() { return this.callback; }
-  cacheable() { return; }
-  exec(content, resource) {
-    return () =>
-      new Promise((resolve) => resolve({ querySchema: "test document" }));
-  }
-  load(testContent) { return this.loader(testContent); }
-}
+
 
 test('cashay-loader is function', t => {
   t.plan(1);
@@ -23,8 +11,49 @@ test('cashay-loader is function', t => {
   t.is(typeof cashayLoader, 'function');
 });
 
-test.cb('cashay-loader returns raw module object', t => {
+test.cb('cashay-loader w/o resourceQuery returns raw module object', t => {
   t.plan(2);
+
+  class MockLoaderParent {
+    constructor(loader, testCallback) {
+      this.loader = loader;
+      this.callback = testCallback;
+    }
+    async() { return this.callback; }
+    cacheable() { return; }
+    exec(content, resource) {
+      return new Promise((resolve) => resolve({ querySchema: "test document" }));
+    }
+    load(testContent) { return this.loader(testContent); }
+  }
+
+  const callback = (errors, doc) => {
+    t.is(errors, null);
+    t.regex(doc, /^module.exports = {/);
+    t.end();
+  }
+
+  const loader = new MockLoaderParent(cashayLoader, callback);
+  loader.load();
+});
+
+test.cb('cashay-loader w/o resourceQuery returns raw module object', t => {
+  t.plan(2);
+
+  class MockLoaderParent {
+    constructor(loader, testCallback) {
+      this.loader = loader;
+      this.callback = testCallback;
+      this.resourceQuery = "?thisIsATest";
+    }
+    async() { return this.callback; }
+    cacheable() { return; }
+    exec(content, resource) {
+      return () =>
+        new Promise((resolve) => resolve({ querySchema: "test document" }));
+    }
+    load(testContent) { return this.loader(testContent); }
+  }
 
   const callback = (errors, doc) => {
     t.is(errors, null);

--- a/src/schema/__tests__/cashay-loader-tests.js
+++ b/src/schema/__tests__/cashay-loader-tests.js
@@ -3,7 +3,19 @@ import test from 'ava';
 
 import cashayLoader from '../cashay-loader';
 
-
+class MockLoaderParent {
+  constructor(loader, testCallback) {
+    this.loader = loader;
+    this.callback = testCallback;
+  }
+  async() { return this.callback; }
+  cacheable() { return; }
+  exec(content, resource) {
+    return () =>
+      new Promise((resolve) => resolve({ querySchema: "test document" }));
+  }
+  load(testContent) { return this.loader(testContent); }
+}
 
 test('cashay-loader is function', t => {
   t.plan(1);
@@ -11,49 +23,8 @@ test('cashay-loader is function', t => {
   t.is(typeof cashayLoader, 'function');
 });
 
-test.cb('cashay-loader w/o resourceQuery returns raw module object', t => {
+test.cb('cashay-loader returns raw module object', t => {
   t.plan(2);
-
-  class MockLoaderParent {
-    constructor(loader, testCallback) {
-      this.loader = loader;
-      this.callback = testCallback;
-    }
-    async() { return this.callback; }
-    cacheable() { return; }
-    exec(content, resource) {
-      return new Promise((resolve) => resolve({ querySchema: "test document" }));
-    }
-    load(testContent) { return this.loader(testContent); }
-  }
-
-  const callback = (errors, doc) => {
-    t.is(errors, null);
-    t.regex(doc, /^module.exports = {/);
-    t.end();
-  }
-
-  const loader = new MockLoaderParent(cashayLoader, callback);
-  loader.load();
-});
-
-test.cb('cashay-loader w/o resourceQuery returns raw module object', t => {
-  t.plan(2);
-
-  class MockLoaderParent {
-    constructor(loader, testCallback) {
-      this.loader = loader;
-      this.callback = testCallback;
-      this.resourceQuery = "?thisIsATest";
-    }
-    async() { return this.callback; }
-    cacheable() { return; }
-    exec(content, resource) {
-      return () =>
-        new Promise((resolve) => resolve({ querySchema: "test document" }));
-    }
-    load(testContent) { return this.loader(testContent); }
-  }
 
   const callback = (errors, doc) => {
     t.is(errors, null);

--- a/src/schema/__tests__/cashay-loader-tests.js
+++ b/src/schema/__tests__/cashay-loader-tests.js
@@ -11,7 +11,8 @@ class MockLoaderParent {
   async() { return this.callback; }
   cacheable() { return; }
   exec(content, resource) {
-    return new Promise((resolve) => resolve({ querySchema: "test document" }));
+    return () =>
+      new Promise((resolve) => resolve({ querySchema: "test document" }));
   }
   load(testContent) { return this.loader(testContent); }
 }

--- a/src/schema/cashay-loader.js
+++ b/src/schema/cashay-loader.js
@@ -4,7 +4,7 @@ module.exports = function(content) {
   const callback = this.async();
   // Execute the supplied javascript, receive promise:
   const doc = this.exec(content, this.resource);
-  doc.then(function (schema) {
+  doc(this.resourceQuery).then(function (schema) {
     // Await the yield of a cashay schema:
     callback(null, "module.exports = " + JSON.stringify(schema));
   });

--- a/src/schema/cashay-loader.js
+++ b/src/schema/cashay-loader.js
@@ -2,9 +2,16 @@ module.exports = function(content) {
   // Allow webpack to be smart about required dependencies:
   this.cacheable && this.cacheable();
   const callback = this.async();
-  // Execute the supplied javascript, receive promise:
-  const doc = this.exec(content, this.resource);
-  doc(this.resourceQuery).then(function (schema) {
+
+  // Execute the supplied javascript:
+  let doc = this.exec(content, this.resource);
+  if (this.resourceQuery) {
+    // if we've been given a resource query, evaluate the doc as a function
+    // yielding a promise:
+    doc = doc(this.resourceQuery);
+  }
+
+  doc.then(function (schema) {
     // Await the yield of a cashay schema:
     callback(null, "module.exports = " + JSON.stringify(schema));
   });

--- a/src/schema/cashay-loader.js
+++ b/src/schema/cashay-loader.js
@@ -2,16 +2,9 @@ module.exports = function(content) {
   // Allow webpack to be smart about required dependencies:
   this.cacheable && this.cacheable();
   const callback = this.async();
-
-  // Execute the supplied javascript:
-  let doc = this.exec(content, this.resource);
-  if (this.resourceQuery) {
-    // if we've been given a resource query, evaluate the doc as a function
-    // yielding a promise:
-    doc = doc(this.resourceQuery);
-  }
-
-  doc.then(function (schema) {
+  // Execute the supplied javascript, receive promise:
+  const doc = this.exec(content, this.resource);
+  doc(this.resourceQuery).then(function (schema) {
     // Await the yield of a cashay schema:
     callback(null, "module.exports = " + JSON.stringify(schema));
   });


### PR DESCRIPTION
I changed the signature `cashay-loader` expects to return a function for a Promise instead of a raw promise.

This allows us to pass in a parameter string from the loader to the user-provided module which is, by my estimation, way better™.

It also will fix our little conundrum in Action where sometimes we want rethink to exit, sometimes we don't. Like this:

```js
let cashaySchema = null;
if (__CLIENT__) {
  /*
   * During the client bundle build, the server will need to be stopped:
   */
  // eslint-disable-next-line global-require
  cashaySchema = require('cashay!../server/utils/getCashaySchema.js?stopRethink');
} else {
  /*
   * Hey! We're the server. No need to stop rethink. The server will
   * take care of that when it wants to exit.
   */
  // eslint-disable-next-line global-require
  cashaySchema = require('cashay!../server/utils/getCashaySchema.js');
}
```