### PR TITLE
Move babel-runtime to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
     "babel-preset-es2015": "6.9.0",
     "babel-preset-stage-0": "6.5.0",
     "babel-register": "^6.9.0",
-    "babel-runtime": "^6.9.2",
     "coveralls": "^2.11.9",
     "nyc": "^6.4.4",
     "rimraf": "2.5.2",
     "xo": "0.15.1"
   },
   "dependencies": {
+    "babel-runtime": "^6.9.2",
     "graphql": "0.6.0",
     "isomorphic-fetch": "^2.2.1",
     "minimist": "^1.2.0"


### PR DESCRIPTION
babel-runtime seems to be needed in user-space here.  Otherwise I am getting errors e.g.:

```
Cannot find module 'babel-runtime/core-js/object/keys'
Error: Cannot find module 'babel-runtime/core-js/object/keys'
    at Function.Module._resolveFilename (module.js:472:15)
    at Function.Module._load (module.js:420:25)
    at Module.require (module.js:500:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/dustin/Test/my-app/node_modules/cashay/lib/normalize/mergeStores.js:7:13)
```

