### PR TITLE
Fix Cannot read property 'length' of undefined

### DIFF
--- a/src/normalize/__tests__/denormalizeStore-tests.js
+++ b/src/normalize/__tests__/denormalizeStore-tests.js
@@ -175,3 +175,26 @@ test('flag sendToServer = true for array of objects', t => {
   //                                    getPostById ->           keywordsMentioned ->       word
   t.true(context.operation.selectionSet.selections[0].selectionSet.selections[1].selectionSet.selections[0].sendToServer);
 });
+
+test('Same query with another argument', t => {
+  const rawQuery = `
+  query {
+    getCommentsByPostId {
+      _id
+      postId
+      content
+    }
+  }`;
+  const queryAST = parseAndInitializeQuery(rawQuery, clientSchema, idFieldName);
+  const context = buildExecutionContext(queryAST, {
+    variables: {"postId": "p126"},
+    coerceTypes,
+    getState: () => ({entities:{}, result: {getCommentsByPostId: {'"postId": "p123"':[]}}}),
+    idFieldName,
+    paginationWords,
+    schema: clientSchema
+  });
+  const actual = denormalizeStore(context);
+  const expected = {getCommentsByPostId:[{_id:null,postId:null,content:null}]}
+  t.deepEqual(actual, expected)
+});

--- a/src/normalize/denormalizeStore.js
+++ b/src/normalize/denormalizeStore.js
@@ -78,8 +78,12 @@ const visitObject = (subState = {}, reqAST, parentTypeSchema, context, reduction
         if (isPrimitive(nnFieldType.kind) || subState[fieldName] === null) {
           reduction[aliasOrFieldName] = visitScalar(fieldState, context.coerceTypes[typeSchema.name])
         } else {
-          if (nnFieldType.kind === LIST) {
-            reduction[aliasOrFieldName] = visitIterable(fieldState, field, typeSchema, context, aliasOrFieldName);
+          if ((nnFieldType.kind === LIST)) {
+            if (fieldState) {
+              reduction[aliasOrFieldName] = visitIterable(fieldState, field, typeSchema, context, aliasOrFieldName);
+            } else {
+              reduction[aliasOrFieldName] = [visitObject(fieldState, field, typeSchema, context)];
+            }
           } else {
             reduction[aliasOrFieldName] = visitObject(fieldState, field, typeSchema, context);
           }


### PR DESCRIPTION
@mattkrick, @dustinfarris,

After further investigations with @slaivyn we came to the following conclusions and PR:

When you have a query such as ```getCommentsByPostId``` supposed to return a List given an argument (id), if you query first with an argument and then with another one you'll have the error #156. 

The reason is cashay searches for existing data in the same namespace :
[denormalizeStore](https://github.com/mattkrick/cashay/blob/master/src/normalize/denormalizeStore.js#L75) 
[maybeLiveQuery](https://github.com/mattkrick/cashay/blob/27320c4ebd5c5d2ce697479d21a72de7f3d7c73c/src/normalize/denormalizeHelpers.js#L89) 
[getFieldState](https://github.com/mattkrick/cashay/blob/37daaea5f2056cdde851e64f21f04a6fb936e2b5/src/normalize/getFieldState.js)

The last one returns subState = fieldState