### PR TITLE
getMissingRequiredVariables report missing falsy yet valid values

### DIFF
--- a/src/query/__tests__/queryHelpers-data.js
+++ b/src/query/__tests__/queryHelpers-data.js
@@ -1,0 +1,87 @@
+export const getMissingRequiredVariablesTest = {
+  variables: {
+    exampleFloat: 0.0,
+    exampleInt: 0,
+    exampleBoolean: false,
+    exampleString: ''
+  },
+  variableDefinitions: [
+  	{
+  		"kind": "VariableDefinition",
+  		"type": {
+  			"kind": "NamedType",
+  			"name": {
+  				"kind": "Name",
+  				"value": "Float"
+  			}
+  		},
+  		"variable": {
+  			"kind": "Variable",
+  			"name": {
+  				"kind": "Name",
+  				"value": "exampleFloat"
+  			}
+  		}
+  	},
+  	{
+  		"kind": "VariableDefinition",
+  		"type": {
+  			"kind": "NonNullType",
+  			"type": {
+  				"kind": "NamedType",
+  				"name": {
+  					"kind": "Name",
+  					"value": "Int"
+  				}
+  			}
+  		},
+  		"variable": {
+  			"kind": "Variable",
+  			"name": {
+  				"kind": "Name",
+  				"value": "exampleInt"
+  			}
+  		}
+  	},
+  	{
+  		"kind": "VariableDefinition",
+  		"type": {
+  			"kind": "NonNullType",
+  			"type": {
+  				"kind": "NamedType",
+  				"name": {
+  					"kind": "Name",
+  					"value": "Boolean"
+  				}
+  			}
+  		},
+  		"variable": {
+  			"kind": "Variable",
+  			"name": {
+  				"kind": "Name",
+  				"value": "exampleBoolean"
+  			}
+  		}
+  	},
+  	{
+  		"kind": "VariableDefinition",
+  		"type": {
+  			"kind": "NonNullType",
+  			"type": {
+  				"kind": "NamedType",
+  				"name": {
+  					"kind": "Name",
+  					"value": "String"
+  				}
+  			}
+  		},
+  		"variable": {
+  			"kind": "Variable",
+  			"name": {
+  				"kind": "Name",
+  				"value": "exampleString"
+  			}
+  		}
+  	}
+  ]
+};

--- a/src/query/__tests__/queryHelpers-tests.js
+++ b/src/query/__tests__/queryHelpers-tests.js
@@ -1,0 +1,9 @@
+import test from 'ava';
+import {getMissingRequiredVariablesTest} from './queryHelpers-data'
+import {getMissingRequiredVariables} from '../queryHelpers'
+
+test('Valid "falsy" values in getMissingRequiredVariables', t => {
+  const {variableDefinitions, variables} = getMissingRequiredVariablesTest
+  const falsyReportedMissing = getMissingRequiredVariables(variableDefinitions, variables)
+  t.deepEqual(falsyReportedMissing.length, 0);
+});

--- a/src/query/__tests__/queryHelpers-tests.js
+++ b/src/query/__tests__/queryHelpers-tests.js
@@ -1,6 +1,7 @@
 import test from 'ava';
-import {getMissingRequiredVariablesTest} from './queryHelpers-data'
-import {getMissingRequiredVariables} from '../queryHelpers'
+import 'babel-register';
+import {getMissingRequiredVariablesTest} from './queryHelpers-data';
+import {getMissingRequiredVariables} from '../queryHelpers';
 
 test('Valid "falsy" values in getMissingRequiredVariables', t => {
   const {variableDefinitions, variables} = getMissingRequiredVariablesTest

--- a/src/query/queryHelpers.js
+++ b/src/query/queryHelpers.js
@@ -119,12 +119,14 @@ export const invalidateMutationsOnNewQuery = (op, cachedMutations) => {
 };
 
 export const getMissingRequiredVariables = (variableDefinitions, variables) => {
+  console.log({variableDefinitions, variables})
   const missingVars = [];
   for (let i = 0; i < variableDefinitions.length; i++) {
     const def = variableDefinitions[i];
     if (def.type.kind === NON_NULL_TYPE) {
       const defKey = def.variable.name.value;
-      if (!variables[defKey]) {
+      const variableVal = variables[defKey];
+      if (variableVal === undefined || variableVal === null) {
         missingVars.push(defKey);
       }
     }

--- a/src/query/queryHelpers.js
+++ b/src/query/queryHelpers.js
@@ -119,7 +119,6 @@ export const invalidateMutationsOnNewQuery = (op, cachedMutations) => {
 };
 
 export const getMissingRequiredVariables = (variableDefinitions, variables) => {
-  console.log({variableDefinitions, variables})
   const missingVars = [];
   for (let i = 0; i < variableDefinitions.length; i++) {
     const def = variableDefinitions[i];


### PR DESCRIPTION
Hi @mattkrick, 

I found a problem while trying to query something containing a floor in a very basic form. Floor is expected to be a non null Int but very often equals 0. I found out that the falsy values are not handled in 
getMissingRequiredVariables. This PR solves the problem by specifically looking for null or undefined.

*Edit: coverage decreases because the queryHelpers.js file was not in the tests percentage before and I only test one of the few functions of the file*